### PR TITLE
Update KTLOSAQ40Loot.json

### DIFF
--- a/KTLOSAQ40Loot.json
+++ b/KTLOSAQ40Loot.json
@@ -483,7 +483,7 @@
 			"wowID":"21607"
 		},
 		"Vek'nilash's Circlet":{
-			"prio":["Non Mish Casters","Warrior/Priest/Mage/Warlock","EP/GP"],
+			"prio":["Non Mish Casters","Tank prio","EP/GP"],
 			"gp":"5 (War), 8 (Mage/Warlock)",
 			"wowID":"20926"
 		},


### PR DESCRIPTION
I asked you guys to changed this to Tank Prio so that the language was clear. Im doing it myself now. Now when warriors roll for this helm it will go to tanks before any other warrior.