### PR TITLE
Update KTLOSMCLoot.json

### DIFF
--- a/KTLOSMCLoot.json
+++ b/KTLOSMCLoot.json
@@ -643,7 +643,7 @@
 			"wowID":""
 		},
 		"Onslaught Girdle":{
-			"prio":["Impactt","EP/GP"],
+			"prio":["Impactt","Warrior Prio Then Ret."],
 			"gp:":"",
 			"wowID":""
 		},


### PR DESCRIPTION
As it was written before ret paladins would win it if they had more pr. This fixes it so rets cant win it over warriors.