### PR TITLE
More updates

### DIFF
--- a/KTLOSAQ40Loot.json
+++ b/KTLOSAQ40Loot.json
@@ -354,7 +354,7 @@
 			"wowID":"21626"
 		},
 		"Sharpened Silithid Femur":{
-			"prio":["Theprestige(1)","Blacklisted(1)","Coxxy(1)","Meowingtons(1)","Alter(1)","Raehn(1)","Kuku(1)","Austeezy(1)","Caster DPS Prio","EP/GP"],
+			"prio":["Blacklisted(1)","Coxxy(1)","Meowingtons(1)","Alter(1)","Raehn(1)","Kuku(1)","Austeezy(1)","Caster DPS Prio","EP/GP"],
 			"gp":"14",
 			"wowID":"21622"
 		},
@@ -562,7 +562,7 @@
 			"wowID":"22730"
 		},
 		"Cloak of the Devoured":{
-			"prio":["Kuku(1)","Meowingtons(1)","Coxxy(1)","Rasbeary(1)","Theprestige(1)","EP/GP"],
+			"prio":["Meowingtons(1)","Coxxy(1)","Rasbeary(1)","Theprestige(1)","EP/GP"],
 			"gp":"5",
 			"wowID":"22731"
 		},

--- a/KTLOSAQ40Loot.json
+++ b/KTLOSAQ40Loot.json
@@ -562,7 +562,7 @@
 			"wowID":"22730"
 		},
 		"Cloak of the Devoured":{
-			"prio":["Meowingtons(1)","Coxxy(1)","Rasbeary(1)","Theprestige(1)","EP/GP"],
+			"prio":["Coxxy(1)","Rasbeary(1)","Theprestige(1)","EP/GP"],
 			"gp":"5",
 			"wowID":"22731"
 		},

--- a/KTLOSNaxxLoot.json
+++ b/KTLOSNaxxLoot.json
@@ -401,7 +401,7 @@
 			"wowID":"22809"
 		},
 		"Seal of the Damned":{
-			"prio":["Notpq","EP/GP"],
+			"prio":["Kuku(1)","Austeezy(1)","Coxxy(1)","Blacklisted(1)","EP/GP"],
 			"gp":"6",
 			"wowID":"23025"
 		}, 
@@ -455,7 +455,7 @@
 			"wowID":"22810"
 		},
 		"The End of Dreams":{
-			"prio":["Notpq","EP/GP"],
+			"prio":["Rasbeary(1)","Notpq(1)","EP/GP"],
 			"gp":"1",
 			"wowID":"22988"
 		},
@@ -492,7 +492,7 @@
 			"wowID":"23075"
 		},
 		"Rime covered Mantle":{
-			"prio":["LC","EP/GP"],
+			"prio":["Alters(1)","Rhaen(1)","Meow(1)","Theprestige(1)","EP/GP"],
 			"gp":"10",
 			"wowID":"22983"
 		}
@@ -618,7 +618,7 @@
 			"wowID":"23060"
 		},
 		"Gem of Trapped Innocents":{
-			"prio":["Alters(1)","Kuku(1)","EP/GP"],
+			"prio":["Alters(1)","Rasbeary(1)","Kuku(1)","EP/GP"],
 			"gp":"9",
 			"wowID":"23057"
 		},


### PR DESCRIPTION
Add Rasbeary to EOD + Gem.
Rasbeary still needs to be added to Rime covered, but delegating to Prestige since it's a mage only item atm.
Removed Kuku / Prestige from Cloak / Femur.
