### PR TITLE
Update KTLOSNaxxLoot.json

### DIFF
--- a/KTLOSNaxxLoot.json
+++ b/KTLOSNaxxLoot.json
@@ -681,7 +681,7 @@
 			"wowID":"23057"
 		},
 		"Gressil, Dawn of Ruin":{
-			"prio":["Chrixus(sunnyD)","Sniped(crush)","Bendriller(sunnyD)","LC","EP/GP"],
+			"prio":["Chrixus(sunnyD)","Sniped(crush)","Johnscar(sunnyD)","LC","EP/GP"],
 			"gp":"18",
 			"wowID":"23054"
 		},


### PR DESCRIPTION
@forgotaboutdre updating Gressil R2 to Johnscar after Chrixus to maintain the general rule of nobody having 2 KT weps before "equal" performers have 1.